### PR TITLE
Fix for browserify/webpack compatibility.

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 let enabled =
   process.env.FORCE_COLOR ||
   process.platform === "win32" ||
-  (process.stdout.isTTY && process.env.TERM && process.env.TERM !== "dumb")
+  (process.stdout != undefined && process.stdout.isTTY && process.env.TERM && process.env.TERM !== "dumb")
 
 const rawInit = (open, close, searchRegex, replaceValue) => s =>
   enabled

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 let enabled =
   process.env.FORCE_COLOR ||
   process.platform === "win32" ||
-  (process.stdout != undefined && process.stdout.isTTY && process.env.TERM && process.env.TERM !== "dumb")
+  (process.stdout != null && process.stdout.isTTY && process.env.TERM && process.env.TERM !== "dumb")
 
 const rawInit = (open, close, searchRegex, replaceValue) => s =>
   enabled


### PR DESCRIPTION
Checking `process.stdout != undefined` before checking `process.stdout.isTTY` to make sure colorette can be used by other node modules that work with tools like browserify and webpack.