### PR TITLE
Add ESM support

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,50 +27,93 @@ const init = (open, close) => {
   )
 }
 
+const options = Object.defineProperty({}, "enabled", {
+  get: () => enabled,
+  set: (value) => (enabled = value),
+})
+const reset = init(0, 0)
+const bold = raw("\x1b[1m", "\x1b[22m", /\x1b\[22m/g, "\x1b[22m\x1b[1m")
+const dim = raw("\x1b[2m", "\x1b[22m", /\x1b\[22m/g, "\x1b[22m\x1b[2m")
+const italic = init(3, 23)
+const underline = init(4, 24)
+const inverse = init(7, 27)
+const hidden = init(8, 28)
+const strikethrough = init(9, 29)
+const black = init(30, 39)
+const red = init(31, 39)
+const green = init(32, 39)
+const yellow = init(33, 39)
+const blue = init(34, 39)
+const magenta = init(35, 39)
+const cyan = init(36, 39)
+const white = init(37, 39)
+const gray = init(90, 39)
+const bgBlack = init(40, 49)
+const bgRed = init(41, 49)
+const bgGreen = init(42, 49)
+const bgYellow = init(43, 49)
+const bgBlue = init(44, 49)
+const bgMagenta = init(45, 49)
+const bgCyan = init(46, 49)
+const bgWhite = init(47, 49)
+const blackBright = init(90, 39)
+const redBright = init(91, 39)
+const greenBright = init(92, 39)
+const yellowBright = init(93, 39)
+const blueBright = init(94, 39)
+const magentaBright = init(95, 39)
+const cyanBright = init(96, 39)
+const whiteBright = init(97, 39)
+const bgBlackBright = init(100, 49)
+const bgRedBright = init(101, 49)
+const bgGreenBright = init(102, 49)
+const bgYellowBright = init(103, 49)
+const bgBlueBright = init(104, 49)
+const bgMagentaBright = init(105, 49)
+const bgCyanBright = init(106, 49)
+const bgWhiteBright = init(107, 49)
+
 module.exports = {
-  options: Object.defineProperty({}, "enabled", {
-    get: () => enabled,
-    set: (value) => (enabled = value),
-  }),
-  reset: init(0, 0),
-  bold: raw("\x1b[1m", "\x1b[22m", /\x1b\[22m/g, "\x1b[22m\x1b[1m"),
-  dim: raw("\x1b[2m", "\x1b[22m", /\x1b\[22m/g, "\x1b[22m\x1b[2m"),
-  italic: init(3, 23),
-  underline: init(4, 24),
-  inverse: init(7, 27),
-  hidden: init(8, 28),
-  strikethrough: init(9, 29),
-  black: init(30, 39),
-  red: init(31, 39),
-  green: init(32, 39),
-  yellow: init(33, 39),
-  blue: init(34, 39),
-  magenta: init(35, 39),
-  cyan: init(36, 39),
-  white: init(37, 39),
-  gray: init(90, 39),
-  bgBlack: init(40, 49),
-  bgRed: init(41, 49),
-  bgGreen: init(42, 49),
-  bgYellow: init(43, 49),
-  bgBlue: init(44, 49),
-  bgMagenta: init(45, 49),
-  bgCyan: init(46, 49),
-  bgWhite: init(47, 49),
-  blackBright: init(90, 39),
-  redBright: init(91, 39),
-  greenBright: init(92, 39),
-  yellowBright: init(93, 39),
-  blueBright: init(94, 39),
-  magentaBright: init(95, 39),
-  cyanBright: init(96, 39),
-  whiteBright: init(97, 39),
-  bgBlackBright: init(100, 49),
-  bgRedBright: init(101, 49),
-  bgGreenBright: init(102, 49),
-  bgYellowBright: init(103, 49),
-  bgBlueBright: init(104, 49),
-  bgMagentaBright: init(105, 49),
-  bgCyanBright: init(106, 49),
-  bgWhiteBright: init(107, 49),
+  options,
+  reset,
+  bold,
+  dim,
+  italic,
+  underline,
+  inverse,
+  hidden,
+  strikethrough,
+  black,
+  red,
+  green,
+  yellow,
+  blue,
+  magenta,
+  cyan,
+  white,
+  gray,
+  bgBlack,
+  bgRed,
+  bgGreen,
+  bgYellow,
+  bgBlue,
+  bgMagenta,
+  bgCyan,
+  bgWhite,
+  blackBright,
+  redBright,
+  greenBright,
+  yellowBright,
+  blueBright,
+  magentaBright,
+  cyanBright,
+  whiteBright,
+  bgBlackBright,
+  bgRedBright,
+  bgGreenBright,
+  bgYellowBright,
+  bgBlueBright,
+  bgMagentaBright,
+  bgCyanBright,
+  bgWhiteBright,
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "colorette.d.ts",
   "scripts": {
     "test": "nyc -r lcov testmatrix test/index.js",
-    "release": "v=$npm_package_version; git commit -am $v && git tag -s $v -m $v && git push && git push --tags && npm publish"
+    "release": "v=$npm_package_version; git commit -am $v && git tag -s $v -m $v && git push && git push --tags && npx dual-publish"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "homepage": "https://github.com/jorgebucaran/colorette",
   "devDependencies": {
+    "dual-publish": "^0.10.6",
     "nyc": "15.0.1",
     "testmatrix": "0.1.2"
   }


### PR DESCRIPTION
This PR adds ES modules support to colorette. Closes https://github.com/jorgebucaran/colorette/issues/39.

Right now you can’t import functions from colorette in Node.js native ES modules:

```js
// node -v => v14.4.0

import { bold } from 'colorette'
/*       ^^^^
SyntaxError: The requested module 'colorette' is expected to be of type CommonJS, which does not support named exports. 
CommonJS modules can be imported by importing the default export. */
```

To avoid code duplication, I added [`dual-publish`](https://github.com/ai/dual-publish/) tool. You need to call `npx dual-publish` instead of `npm publish`:

1. Copy the project to a temporary directory.
1. It will copy `index.js` to `index.cjs`
2. It will convert `index.js` to ESM
3. It will add the `exports` section to `package.json`
4. Also, it will clean `package.json` from `devDependencies` and development `scripts`.
5. Release the project from this temporary directory to npm.

Benefits of using `dual-publish`:

1. It is used in around [90 npm packages](https://github.com/search?q=%22dual-publish%22&type=Code).
2. I tested it in `nanoid` with [9M downloads](https://npm-stat.com/charts.html?package=nanoid).
3. It has [integration tests](https://github.com/ai/dual-publish/blob/master/test/index.test.js) to be sure, that it works well in a big variety of use cases: Node.js, TypeScript, ts-node, webpack, Rollup, Parcel, React Native
4. It uses `colorette` inside 😸

You can check the tool by calling `npx dual-publish --check`. It will put built to `dual-publish-tmp` without releasing it to npm.

```
$ npx dual-publish --check  
Check npm package content in ./dual-publish-tmp/

$ tree ./dual-publish-tmp/
./dual-publish-tmp/
├── bench // <= this directory will be ignored during the publishing
│   ├── index.js
│   └── package.json
├── colorette.d.ts
├── index.cjs
├── index.js
├── LICENSE.md
├── package.json
└── README.md

1 directory, 8 files

$ cat dual-publish-tmp/index.js 
"use strict"

let enabled =
  !("NO_COLOR" in process.env) &&
  ("FORCE_COLOR" in process.env ||
    process.platform === "win32" ||
    (process.stdout != null &&
      process.stdout.isTTY &&
      process.env.TERM &&
      process.env.TERM !== "dumb"))

const raw = (open, close, searchRegex, replaceValue) => (s) =>
  enabled
    ? open +
      (~(s += "").indexOf(close, 4) // skip opening \x1b[
        ? s.replace(searchRegex, replaceValue)
        : s) +
      close
    : s

const init = (open, close) => {
  return raw(
    `\x1b[${open}m`,
    `\x1b[${close}m`,
    new RegExp(`\\x1b\\[${close}m`, "g"),
    `\x1b[${open}m`
  )
}

const options = Object.defineProperty({}, "enabled", {
  get: () => enabled,
  set: (value) => (enabled = value),
})
const reset = init(0, 0)
const bold = raw("\x1b[1m", "\x1b[22m", /\x1b\[22m/g, "\x1b[22m\x1b[1m")
const dim = raw("\x1b[2m", "\x1b[22m", /\x1b\[22m/g, "\x1b[22m\x1b[2m")
const italic = init(3, 23)
…

export {
  options,
  reset,
  bold,
  dim,
  italic,
  …
}

$ cat dual-publish-tmp/package.json 
{
  "name": "colorette",
  "version": "1.2.0",
  "description": "Color your terminal using pure idiomatic JavaScript.",
  "main": "index.cjs",
  "types": "colorette.d.ts",
  "repository": {
    "type": "git",
    "url": "jorgebucaran/colorette"
  },
  "files": [
    "index.js",
    "colorette.d.ts"
  ],
  "keywords": [
    "colorette",
    "terminal",
    "styles",
    "color",
    "ansi"
  ],
  "author": "Jorge Bucaran",
  "license": "MIT",
  "bugs": {
    "url": "https://github.com/jorgebucaran/colorette/issues"
  },
  "homepage": "https://github.com/jorgebucaran/colorette",
  "type": "module",
  "module": "index.js",
  "react-native": "index.js",
  "exports": {
    "./package.json": "./package.json", // <= this line is required by React Native
    ".": {
      "require": "./index.cjs",
      "import": "./index.js"
    }
  }
}
```