### PR TITLE
Add a benchmark of loading the modules in Node.js by require()

### DIFF
--- a/bench/load.js
+++ b/bench/load.js
@@ -1,0 +1,19 @@
+console.time('colorette');
+const colorette = require('..');
+console.timeEnd('colorette');
+
+console.time('chalk');
+const chalk = require('chalk');
+console.timeEnd('chalk');
+
+console.time('kleur');
+const kleur = require('kleur');
+console.timeEnd('kleur');
+
+console.time('colors');
+const colors = require('colors');
+console.timeEnd('colors');
+
+console.time('ansi-colors');
+const ansiColors = require('ansi-colors');
+console.timeEnd('ansi-colors');

--- a/bench/package.json
+++ b/bench/package.json
@@ -3,8 +3,8 @@
   "dependencies": {
     "benchmark": "^2.1.4",
     "colors": "^1.4.0",
-    "chalk": "^4.0.0",
-    "kleur": "3.0.3",
+    "chalk": "^4.1.0",
+    "kleur": "^4.1.3",
     "ansi-colors": "^4.1.1"
   }
 }


### PR DESCRIPTION
Upgrade the chalk and kleur packages too.

The numbers:

    $ node load

    colorette: 7.422ms
    chalk: 8.522ms
    kleur: 2.424ms
    colors: 10.027ms
    ansi-colors: 2.089ms

    $ node index

    colorette × 654.575 ops/sec
    chalk × 459.724 ops/sec
    kleur × 490.536 ops/sec
    colors × 249.458 ops/sec
    ansi-colors × 331.494 ops/sec
