### PR TITLE
Add Deno and browser support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,12 @@
 let enabled =
-  !("NO_COLOR" in process.env) &&
-  ("FORCE_COLOR" in process.env ||
-    process.platform === "win32" ||
-    (process.stdout != null &&
-      process.stdout.isTTY &&
-      process.env.TERM &&
-      process.env.TERM !== "dumb"))
+  typeof process === "undefined" ||
+  (!("NO_COLOR" in process.env) &&
+    ("FORCE_COLOR" in process.env ||
+      process.platform === "win32" ||
+      (process.stdout != null &&
+        process.stdout.isTTY &&
+        process.env.TERM &&
+        process.env.TERM !== "dumb")))
 
 const raw = (open, close, searchRegex, replaceValue) => (s) =>
   enabled

--- a/index.js
+++ b/index.js
@@ -1,15 +1,18 @@
-let enabled =
-  (typeof process !== "undefined" && // Node.js
-  !("NO_COLOR" in process.env) &&
+let enabled
+
+if (typeof process !== "undefined") {
+  enabled = !("NO_COLOR" in process.env) &&
   ("FORCE_COLOR" in process.env ||
     process.platform === "win32" ||
     (process.stdout != null &&
       process.stdout.isTTY &&
       process.env.TERM &&
-      process.env.TERM !== "dumb"))) ||
-  (typeof Deno !== "undefined" && // Deno
-  !Deno.noColor) &&
-  true // Browser
+      process.env.TERM !== "dumb"))
+} else if (typeof Deno !== "undefined") {
+  enabled = !Deno.noColor
+} else {
+  enabled = true
+}
 
 const raw = (open, close, searchRegex, replaceValue) => (s) =>
   enabled

--- a/index.js
+++ b/index.js
@@ -1,12 +1,15 @@
 let enabled =
-  typeof process === "undefined" ||
-  (!("NO_COLOR" in process.env) &&
-    ("FORCE_COLOR" in process.env ||
-      process.platform === "win32" ||
-      (process.stdout != null &&
-        process.stdout.isTTY &&
-        process.env.TERM &&
-        process.env.TERM !== "dumb")))
+  (typeof process !== "undefined" && // Node.js
+  !("NO_COLOR" in process.env) &&
+  ("FORCE_COLOR" in process.env ||
+    process.platform === "win32" ||
+    (process.stdout != null &&
+      process.stdout.isTTY &&
+      process.env.TERM &&
+      process.env.TERM !== "dumb"))) ||
+  (typeof Deno !== "undefined" && // Deno
+  !Deno.noColor) &&
+  true // Browser
 
 const raw = (open, close, searchRegex, replaceValue) => (s) =>
   enabled

--- a/tests/deno/index.test.js
+++ b/tests/deno/index.test.js
@@ -1,0 +1,63 @@
+import * as c from "../../index.js";
+import { assertEquals } from "https://deno.land/std@0.97.0/testing/asserts.ts";
+
+const styles = [
+  ["reset", "\x1b[0m", "\x1b[0m"],
+  ["bold", "\x1b[1m", "\x1b[22m"],
+  ["dim", "\x1b[2m", "\x1b[22m"],
+  ["italic", "\x1b[3m", "\x1b[23m"],
+  ["underline", "\x1b[4m", "\x1b[24m"],
+  ["inverse", "\x1b[7m", "\x1b[27m"],
+  ["hidden", "\x1b[8m", "\x1b[28m"],
+  ["strikethrough", "\x1b[9m", "\x1b[29m"],
+  ["black", "\x1b[30m", "\x1b[39m"],
+  ["red", "\x1b[31m", "\x1b[39m"],
+  ["green", "\x1b[32m", "\x1b[39m"],
+  ["yellow", "\x1b[33m", "\x1b[39m"],
+  ["blue", "\x1b[34m", "\x1b[39m"],
+  ["magenta", "\x1b[35m", "\x1b[39m"],
+  ["cyan", "\x1b[36m", "\x1b[39m"],
+  ["white", "\x1b[37m", "\x1b[39m"],
+  ["gray", "\x1b[90m", "\x1b[39m"],
+  ["bgBlack", "\x1b[40m", "\x1b[49m"],
+  ["bgRed", "\x1b[41m", "\x1b[49m"],
+  ["bgGreen", "\x1b[42m", "\x1b[49m"],
+  ["bgYellow", "\x1b[43m", "\x1b[49m"],
+  ["bgBlue", "\x1b[44m", "\x1b[49m"],
+  ["bgMagenta", "\x1b[45m", "\x1b[49m"],
+  ["bgCyan", "\x1b[46m", "\x1b[49m"],
+  ["bgWhite", "\x1b[47m", "\x1b[49m"],
+  ["blackBright", "\x1b[90m", "\x1b[39m"],
+  ["redBright", "\x1b[91m", "\x1b[39m"],
+  ["greenBright", "\x1b[92m", "\x1b[39m"],
+  ["yellowBright", "\x1b[93m", "\x1b[39m"],
+  ["blueBright", "\x1b[94m", "\x1b[39m"],
+  ["magentaBright", "\x1b[95m", "\x1b[39m"],
+  ["cyanBright", "\x1b[96m", "\x1b[39m"],
+  ["whiteBright", "\x1b[97m", "\x1b[39m"],
+  ["bgBlackBright", "\x1b[100m", "\x1b[49m"],
+  ["bgRedBright", "\x1b[101m", "\x1b[49m"],
+  ["bgGreenBright", "\x1b[102m", "\x1b[49m"],
+  ["bgYellowBright", "\x1b[103m", "\x1b[49m"],
+  ["bgBlueBright", "\x1b[104m", "\x1b[49m"],
+  ["bgMagentaBright", "\x1b[105m", "\x1b[49m"],
+  ["bgCyanBright", "\x1b[106m", "\x1b[49m"],
+  ["bgWhiteBright", "\x1b[107m", "\x1b[49m"],
+];
+
+Deno.test("simple", () => {
+  styles.forEach(([name, open, close]) =>
+    assertEquals(c[name](name), open + name + close)
+  );
+});
+Deno.test("nesting", () => {
+  assertEquals(
+    c.bold(`BOLD ${c.red(`RED ${c.dim("DIM")} RED`)} BOLD`),
+    `\x1b[1mBOLD \x1b[31mRED \x1b[2mDIM\x1b[22m\x1b[1m RED\x1b[39m BOLD\x1b[22m`,
+  );
+});
+Deno.test("numbers & others", () => {
+  [new Date(), -1e10, -1, -0.1, 0, 0.1, 1, 1e10].map((n) =>
+    assertEquals(c.red(n), `\x1b[31m${n}\x1b[39m`)
+  );
+});

--- a/tests/deno/options.test.js
+++ b/tests/deno/options.test.js
@@ -1,0 +1,8 @@
+import * as c from "../../index.js";
+import { assertEquals } from "https://deno.land/std@0.97.0/testing/asserts.ts";
+
+Deno.test("options.enabled toggle color on/off", () => {
+  c.options.enabled = false;
+  assertEquals(c.bold("megazord"), "megazord");
+  c.options.enabled = true;
+});

--- a/tests/deno/scripts/FORCE_COLOR.sh
+++ b/tests/deno/scripts/FORCE_COLOR.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+DENO_OUT=`FORCE_COLOR= deno run tests/deno/scripts/no_color.js`
+PRINTF_OUT=`printf '\e[34mwindow\e[39m'`
+if [ $DENO_OUT = $PRINTF_OUT ]; then
+    exit 0
+  else
+    exit 1
+fi

--- a/tests/deno/scripts/NO_COLOR.sh
+++ b/tests/deno/scripts/NO_COLOR.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+DENO_OUT=`NO_COLOR= deno run tests/deno/scripts/no_color.js`
+PRINTF_OUT=`printf 'window'`
+if [ $DENO_OUT = $PRINTF_OUT ]; then
+    exit 0
+  else
+    exit 1
+fi

--- a/tests/deno/scripts/no_color.js
+++ b/tests/deno/scripts/no_color.js
@@ -1,0 +1,2 @@
+import { blue } from "../../../index.js"
+console.log(blue("window"))

--- a/tests/deno/variables.test.js
+++ b/tests/deno/variables.test.js
@@ -1,0 +1,22 @@
+import { dirname, fromFileUrl } from "https://deno.land/std@0.97.0/path/mod.ts";
+import { assert } from "https://deno.land/std@0.97.0/testing/asserts.ts";
+
+const SCRIPTS_PATH = `${dirname(fromFileUrl(import.meta.url))}/scripts`;
+
+Deno.test("`FORCE_COLOR` forces color", async () => {
+  const p = Deno.run({
+    cmd: ["sh", `${SCRIPTS_PATH}/FORCE_COLOR.sh`],
+  });
+  const {success} = await p.status();
+  assert(success);
+  Deno.close(p.rid);
+})
+
+Deno.test("`NO_COLOR` disables color", async () => {
+  const p = Deno.run({
+    cmd: ["sh", `${SCRIPTS_PATH}/NO_COLOR.sh`],
+  });
+  const {success} = await p.status();
+  assert(success);
+  Deno.close(p.rid);
+})


### PR DESCRIPTION
The `process` module works only in Node.js. To run `colorette` in the browser and [Deno](https://deno.land), we need to check if `process` is undefined. Otherwise this throws an error `process is not defined`.