### PR TITLE
Check if process is defined for better browser compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 let enabled =
+  typeof process !== 'undefined' &&
   !("NO_COLOR" in process.env) &&
   ("FORCE_COLOR" in process.env ||
     process.platform === "win32" ||


### PR DESCRIPTION
Added a little extra check to prevent `process is not defined` error when the library is included in the browser build by webpack 5.