### PR TITLE
Add workflow to run benchmarks

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -9,4 +9,4 @@ jobs:
         with:
           node-version: 16
       - name: Benchmarks
-        run: npm --prefix bench start
+        run: FORCE_COLOR= npm --prefix bench start

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,12 @@
+name: Benchmarks
+on: [push, pull_request]
+jobs:
+  bench:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+      - name: Benchmarks
+        run: npm --prefix bench start


### PR DESCRIPTION
Hello, I just found out colorette and was curious about how it performs. So I had to clone the repo to run the benchmark.

Would you mind if the repo runs regularly the benchmarks via GH actions? So anyone wouls be able to check the benchmarks results through the logs. The readme could link to the logs of this new workflow (for example: https://github.com/jorgebucaran/colorette/actions/workflows/bench.yml).

Data will be relatively up to date without requiring extra effort (no need to include the results in the repo). The results should be fairly consistent too since it runs on the CI server.

Here an example from my fork: https://github.com/pioug/colorette/runs/3575179792?check_suite_focus=true#step:4:15
