### PR TITLE
`vite` compatibility: Lazily evaluate `enabled` checks.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,20 +1,20 @@
 import * as tty from "tty"
 
-const env = process.env
+const env = process?.env || {}
 
-const isDisabled = "NO_COLOR" in env
-const isForced = "FORCE_COLOR" in env
-const isWindows = process.platform === "win32"
+const isDisabled = () => "NO_COLOR" in env
+const isForced = () => "FORCE_COLOR" in env
+const isWindows = () => process.platform === "win32"
 
 const isCompatibleTerminal =
-  tty && tty.isatty(1) && env.TERM && env.TERM !== "dumb"
+  () => tty?.isatty?.(1) && env.TERM && env.TERM !== "dumb"
 
 const isCI =
-  "CI" in env &&
-  ("GITHUB_ACTIONS" in env || "GITLAB_CI" in env || "CIRCLECI" in env)
+  () => "CI" in env &&
+        ("GITHUB_ACTIONS" in env || "GITLAB_CI" in env || "CIRCLECI" in env)
 
 let enabled =
-  !isDisabled && (isForced || isWindows || isCompatibleTerminal || isCI)
+  !isDisabled() && (isForced() || isWindows() || isCompatibleTerminal() || isCI())
 
 const raw = (open, close, searchRegex, replaceValue) => (s) =>
   enabled


### PR DESCRIPTION
Lazily evaluate `enabled` checks and do not fail if `process.env` is not set.

Both issues occur in `vite`'s dev HMR mode, where plain, uncompiled JS modules are imported into the browser.

This makes using `sanitize-html` impossible with `vite`, since `sanitize-html` imports `postcss` into browserland in order to parse CSS into an AST for sanitization. `postcss` uses `colorette`, which fail in the browser without this PR.

This PR fixes https://github.com/jorgebucaran/colorette/issues/67