### PR TITLE
Don't format empty strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,14 +16,15 @@ const isCI =
 export const isColorSupported =
   !isDisabled && (isForced || isWindows || isCompatibleTerminal || isCI)
 
-const raw = (open, close, searchRegex, replaceValue) => (s) =>
-  (s += "")
-    ? open +
-      (~s.indexOf(close, 4) // skip opening \x1b[
-        ? s.replace(searchRegex, replaceValue)
-        : s) +
-      close
-    : ""
+const raw = (open, close, searchRegex, replaceValue) => 
+  (s = "") =>
+    ((s += "") === "")
+      ? s
+      : open +
+        (~s.indexOf(close, 4) // skip opening \x1b[
+          ? s.replace(searchRegex, replaceValue)
+          : s) +
+        close
 
 const init = (open, close) =>
   raw(

--- a/index.js
+++ b/index.js
@@ -16,12 +16,13 @@ const isCI =
 export const isColorSupported =
   !isDisabled && (isForced || isWindows || isCompatibleTerminal || isCI)
 
-const raw = (open, close, searchRegex, replaceValue) => 
+const raw =
+  (open, close, searchRegex, replaceValue) =>
   (s = "") =>
-    ((s += "") === "")
+    s === ""
       ? s
       : open +
-        (~s.indexOf(close, 4) // skip opening \x1b[
+        (~(s += "").indexOf(close, 4) // skip opening \x1b[
           ? s.replace(searchRegex, replaceValue)
           : s) +
         close

--- a/index.js
+++ b/index.js
@@ -17,11 +17,13 @@ export const isColorSupported =
   !isDisabled && (isForced || isWindows || isCompatibleTerminal || isCI)
 
 const raw = (open, close, searchRegex, replaceValue) => (s) =>
-  open +
-  (~(s += "").indexOf(close, 4) // skip opening \x1b[
-    ? s.replace(searchRegex, replaceValue)
-    : s) +
-  close
+  (s += "")
+    ? open +
+      (~s.indexOf(close, 4) // skip opening \x1b[
+        ? s.replace(searchRegex, replaceValue)
+        : s) +
+      close
+    : ""
 
 const init = (open, close) =>
   raw(

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -63,5 +63,15 @@ export default [
         equal(c.red(n), `\x1b[31m${n}\x1b[39m`)
       ),
     ]),
+    t("empty & falsy values", [
+      equal(c.blue(), ""),
+      equal(c.blue(""), ""),
+      equal(c.blue([]), ""),
+      equal(c.blue(undefined), ""),
+      equal(c.blue(0), "\x1b[34m0\x1b[39m"),
+      equal(c.blue(null), "\x1b[34mnull\x1b[39m"),
+      equal(c.blue(false), "\x1b[34mfalse\x1b[39m"),
+      equal(c.blue(NaN), "\x1b[34mNaN\x1b[39m"),
+    ]),
   ]),
 ]

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -66,7 +66,6 @@ export default [
     t("empty & falsy values", [
       equal(c.blue(), ""),
       equal(c.blue(""), ""),
-      equal(c.blue([]), ""),
       equal(c.blue(undefined), ""),
       equal(c.blue(0), "\x1b[34m0\x1b[39m"),
       equal(c.blue(null), "\x1b[34mnull\x1b[39m"),


### PR DESCRIPTION
Chalk has this feature that when a string is empty, it doesn't add opening and closing modifiers to it, unlike Colorette:

```node
> chalk.bold('')
''
> colorette.bold('')
'\x1B[1m\x1B[22m'
```

This makes the migration from Chalk sometimes problematic, especially in tests, which often depend on pre-generated fixtures. Apart from that, returning a self-closing ANSI sequence seems suboptimal to me.

This PR rewrites the `raw()` function and adds a string length check. This didn't seem to cause any slowdowns when running benchmarks, since the needed conversion has been done anyway.
