### PR TITLE
Use faster-than-regex .substring() slicing

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ const replaceClose = (
   next = tail.indexOf(close)
 ) => head + (next >= 0 ? replaceClose(tail, close, replace, next) : tail)
 
-const clearNested = (s, open, close, replace, index) =>
+const clearBleeding = (s, open, close, replace, index) =>
   index >= 0
     ? open + replaceClose(s, close, replace, index) + close
     : open + s + close
@@ -36,7 +36,7 @@ const filterEmpty =
   (open, close, replace = open) =>
   (s) =>
     s || !(s === "" || s === undefined)
-      ? clearNested(
+      ? clearBleeding(
           s,
           open,
           close,


### PR DESCRIPTION
This improves runtime performance when clearing bleeding sequences, using `.substring()` rather than regexes.
    
This clever idea is inspired by @alexeyraspopov's [`replaceClose`](https://github.com/alexeyraspopov/picocolors/blob/2e4e0236139e654cd010a911152307dd0a90da6e/picocolors.js#L23-L26) function in picocolors. Thank you for that! 🙌 