### PR TITLE
Fix export default for all colors

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ export const createColors = ({ useColor = isColorSupported } = {}) =>
         {}
       )
 
-const colors = createColors()
+const color = createColors()
 export const {
   reset,
   bold,
@@ -145,6 +145,6 @@ export const {
   bgMagentaBright,
   bgCyanBright,
   bgWhiteBright,
-} = colors
+} = color
 
-export default colors
+export default color


### PR DESCRIPTION
## Problems

For example if I do this, will get an error:
```ts
import c from 'colorette'

// types safe but get the error in runtime.
c.cyan('hello') // TypeError: Cannot read properties of undefined (reading 'cyan')
```

And then need to change to:

```ts
import * as c from 'colorette'

c.cyan('hello')
```

So I'm not sure if there was a special reason for this design? otherwise the general import usage case would be more reasonable and matched the type system.😅