### PR TITLE
Color functions should always return a string

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,13 +92,11 @@ const colors = {
   bgWhiteBright: init(107, 49),
 }
 
-const none = (any) => any
-
 export const createColors = ({ useColor = isColorSupported } = {}) =>
   useColor
     ? colors
     : Object.keys(colors).reduce(
-        (colors, key) => ({ ...colors, [key]: none }),
+        (colors, key) => ({ ...colors, [key]: String }),
         {}
       )
 

--- a/tests/createColors.test.js
+++ b/tests/createColors.test.js
@@ -7,14 +7,9 @@ export default [
       t("useColor overrides automatic color detection", [
         (done) => {
           done([
-            equal(
-              blue("megazord"),
-              createColors({ useColor: true }).blue("megazord")
-            ),
-            equal(
-              "megazord",
-              createColors({ useColor: false }).blue("megazord")
-            ),
+            equal(blue("foo"), createColors({ useColor: true }).blue("foo")),
+            equal("foo", createColors({ useColor: false }).blue("foo")),
+            equal("42", createColors({ useColor: false }).blue(42)),
           ])
         },
       ]),


### PR DESCRIPTION
Color functions should always return a string according to our public API.

This is technically a bug fix and unlikely to be an issue for anyone, but we could do a minor release just to be sure.