### PR TITLE
Fix detection of dumb terminals on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,16 +6,17 @@ const argv = process.argv || []
 const isDisabled = "NO_COLOR" in env || argv.includes("--no-color")
 const isForced = "FORCE_COLOR" in env || argv.includes("--color")
 const isWindows = process.platform === "win32"
+const isDumbTerminal = env.TERM === "dumb"
 
 const isCompatibleTerminal =
-  tty && tty.isatty && tty.isatty(1) && env.TERM && env.TERM !== "dumb"
+  tty && tty.isatty && tty.isatty(1) && env.TERM && !isDumbTerminal
 
 const isCI =
   "CI" in env &&
   ("GITHUB_ACTIONS" in env || "GITLAB_CI" in env || "CIRCLECI" in env)
 
 export const isColorSupported =
-  !isDisabled && (isForced || isWindows || isCompatibleTerminal || isCI)
+  !isDisabled && (isForced || (isWindows && !isDumbTerminal) || isCompatibleTerminal || isCI)
 
 const replaceClose = (
   index,


### PR DESCRIPTION
The default Windows terminal doesn't set `env.TERM` so we cannot require the variable to be set like on other platforms but if it is set, we should use it because there are many third-party terminals, particularly those embedded in various GUI apps, that don't support colors and correctly set this variable. Fixes #90.

Precommit checks in GitHub Desktop app (before):

![image](https://user-images.githubusercontent.com/6192491/171867984-c383816a-c438-4e89-bac9-43db241b0a6d.png)

After:

![image](https://user-images.githubusercontent.com/6192491/171868138-bf598b86-0d80-453d-b5c6-b7cb2bfdac8d.png)
