### PR TITLE
fix: add `types` to `exports` for `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "./package.json": "./package.json",
     ".": {
       "require": "./index.cjs",
-      "import": "./index.js"
+      "import": "./index.js",
+      "types": "./index.d.ts"
     }
   },
   "files": [


### PR DESCRIPTION
### Summary

`types` corresponds to `main` only. `main/types` will be completely ignored by Node/TypeScript if `exports` is defined. This is mentioned at https://github.com/microsoft/TypeScript/issues/49160#issuecomment-1137482639

Related to https://github.com/kulshekhar/ts-jest/issues/3800