### PR TITLE
isColorSupported is showing TRUE for non-tty Windows terminals

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,8 +11,10 @@ const isForced = "FORCE_COLOR" in env || argv.includes("--color")
 const isWindows = platform === "win32"
 const isDumbTerminal = env.TERM === "dumb"
 
+const isTty = tty && tty.isatty && tty.isatty(1)
+
 const isCompatibleTerminal =
-  tty && tty.isatty && tty.isatty(1) && env.TERM && !isDumbTerminal
+  isTty && env.TERM && !isDumbTerminal
 
 const isCI =
   "CI" in env &&
@@ -20,7 +22,7 @@ const isCI =
 
 export const isColorSupported =
   !isDisabled &&
-  (isForced || (isWindows && !isDumbTerminal) || isCompatibleTerminal || isCI)
+  (isForced || (isWindows && !isDumbTerminal && isTty) || isCompatibleTerminal || isCI)
 
 const replaceClose = (
   index,


### PR DESCRIPTION
Exported `isColorSupported` property returns wrong value (`true`) for Windows terminals that has no TTY support, such as Visual Studio Code Output window, etc. That affects libraries, like lint-staged, who rely on it.

The code below should return `false` for VS Code Output window, but instead returns true:
```bash
node -e "console.log(require('colorette').isColorSupported)"
```
This PR enhances this behavior, by adding additional TTY support check.