### PR TITLE
fix: move `types` condition to the front

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "types": "./index.d.ts",
       "require": "./index.cjs",
-      "import": "./index.js",
-      "types": "./index.d.ts"
+      "import": "./index.js"
     }
   },
   "files": [


### PR DESCRIPTION
I moved `types` condition to the front. `package.json#exports` are **order-sensitive** - they are always matched from the top to the bottom. When a match is found then it should be used and no further matching should occur. 

Right now, the current setup works in TypeScript but it's considered a bug and it should not be relied upon, see the thread and the comment [here](https://github.com/microsoft/TypeScript/issues/50762#issuecomment-1528318260). For that reason, I would like to fix all popular packages that misconfigured their `exports` this way so the bug can be fixed in TypeScript.

⚠️ note that this only fixes one problem but this package is still broken~ for TS consumption form CJS modules. By checking this package with [`arethetypeswrong`](https://arethetypeswrong.github.io/?p=colorette%402.0.20) we can verify that:
> Imports of "colorette" resolved to ES modules from a CJS importing module. CJS modules in Node will only be able to access this entrypoint with a dynamic import.
