### PR TITLE
Add node:util.styleText to benchmark

### DIFF
--- a/bench/index.js
+++ b/bench/index.js
@@ -6,17 +6,22 @@ import kleur from "kleur"
 import colors from "colors"
 import picocolors from "picocolors"
 import ansicolors from "ansi-colors"
+import { styleText } from "node:util"
 
 const test = (c) =>
   c.red(`${c.bold(`${c.cyan(`${c.yellow("yellow")}cyan`)}`)}red`)
 
+const testNode = () => 
+  styleText("red", `${styleText(["bold", "cyan"], `${styleText("yellow", "yellow")}cyan`)}red`)
+
 new bench.Suite()
-  .add("  chalk       ", () => test(chalk))
-  .add("  kleur       ", () => test(kleur))
-  .add("  colors      ", () => test(colors))
-  .add("  ansi-colors ", () => test(ansicolors))
-  .add("  picocolors  ", () => test(picocolors))
-  .add("+ colorette   ", () => test(colorette))
+  .add("  chalk               ", () => test(chalk))
+  .add("  kleur               ", () => test(kleur))
+  .add("  colors              ", () => test(colors))
+  .add("  ansi-colors         ", () => test(ansicolors))
+  .add("  picocolors          ", () => test(picocolors))
+  .add("  node:util.styleText ", () => testNode())
+  .add("+ colorette           ", () => test(colorette))
   .on("cycle", ({ target: { name, hz } }) =>
     console.log(name, `${Math.floor(hz).toLocaleString()} ops/sec`.padStart(18))
   )


### PR DESCRIPTION
Add Node [`util.styleText`](https://nodejs.org/api/util.html#utilstyletextformat-text-options) benchmark to compare the performance of `node:util.styleText`.

`util.styleText` is stable from: `v23.5.0`, `v22.13.0`.
I think it's a worthwhile addition to the benchmark to compare to the node built in.

In order to benchmark this change I have also updated the benchmark node version to 22 which is the latest LTS version. Without changing the bench node version `util.styleText` is not available. Node.js 16 is past it's EOL, either way. Happy to do a seperate pr for that change if preferred