### PR TITLE
update Node.js version to 22 in benchmark workflow

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -7,6 +7,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 22
       - name: Benchmarks
         run: FORCE_COLOR= npm --prefix bench start


### PR DESCRIPTION
Updates the Node.js version used in the benchmark workflow configuration. The workflow now uses Node.js version 22 instead of version 16, 

Why v22? 
This is an LTS version of node until 2027-04-30, and the version required to benchmark against `util.styleText`

Follow up from https://github.com/jorgebucaran/colorette/pull/109#issuecomment-3365316473